### PR TITLE
Update to Lume 3

### DIFF
--- a/demo-repository/docs/deno.json
+++ b/demo-repository/docs/deno.json
@@ -1,10 +1,10 @@
 {
   "tasks": {
-    "lume": "echo \"import 'lume/cli.ts'\" | deno run --unstable -A -",
+    "lume": "echo \"import 'lume/cli.ts'\" | deno run -A -",
     "serve": "deno task lume -s --port=8000"
   },
   "imports": {
-    "lume/": "https://deno.land/x/lume@v2.3.3/",
-    "lumocs/": "https://deno.land/x/lumocs@0.1.3/"
+    "lume/": "https://deno.land/x/lume@v3.0.0/",
+    "lumocs/": "https://deno.land/x/lumocs@0.2.0/"
   }
 }

--- a/deno.json
+++ b/deno.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.1.3",
+  "version": "0.2.0",
   "lint": {
     "exclude": [
       "**/_site"

--- a/init.ts
+++ b/init.ts
@@ -1,11 +1,11 @@
 // Define Lume and Lumocs versions here
-const lumeVersion = "v2.3.3";
-const lumocsVersion = "0.1.3";
+const lumeVersion = "v3.0.0";
+const lumocsVersion = "0.2.0";
 
 // deno.json template
 const denoJsonTemplate = `{
   "tasks": {
-    "lume": "echo \\"import 'lume/cli.ts'\\" | deno run --unstable -A -",
+    "lume": "echo \\"import 'lume/cli.ts'\\" | deno run -A -",
     "serve": "deno task lume -s --port=8000"
   },
   "imports": {

--- a/plugins.ts
+++ b/plugins.ts
@@ -92,7 +92,7 @@ export default function (options: Options = {}) {
 
     // Copy files
     site
-      .copy("css")
-      .copy("js");
+      .add("css")
+      .add("js");
   };
 }


### PR DESCRIPTION
Lume 3 [was released yesterday](https://lume.land/blog/posts/lume-3/) and all themes not supporting the new version were disabled temporately.

This PR brings support for Lume 3 to this theme:

BTW, I'm not sure about the init.ts file, because it has fixed versions of Lume and Lumocs. Themes in Lume can be installed with `deno run -A https://lume.land/init.ts --theme=lumocs` that uses the latest version of Lume and latest version of the theme. I left it as is, because maybe you prefer to install it in this way, but I mention it just in case.